### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ DerivedData
 *.hmap
 *.ipa
 
+# Swift Package Manager
+.swiftpm
+
 # Bundler
 .bundle
 

--- a/DMScrollBar/DMScrollBarConfiguration.swift
+++ b/DMScrollBar/DMScrollBarConfiguration.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension DMScrollBar {
     public struct Configuration: Equatable {
         /// Indicates if the scrollbar should always be visible

--- a/DMScrollBar/ScrollBarIndicator.swift
+++ b/DMScrollBar/ScrollBarIndicator.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 final class ScrollBarIndicator: UIView {
     private var indicatorImageWidthConstraint: NSLayoutConstraint?
     private var indicatorImageHeightConstraint: NSLayoutConstraint?

--- a/DMScrollBar/ScrollBarInfoView.swift
+++ b/DMScrollBar/ScrollBarInfoView.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 final class ScrollBarInfoView: UIView {
     private let offsetLabel = UILabel()
 

--- a/DMScrollBar/Utils/Configuration+Utils.swift
+++ b/DMScrollBar/Utils/Configuration+Utils.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension DMScrollBar.Configuration.RoundedCorners.Corner {
     var cornerMask: CACornerMask {
         switch self {

--- a/DMScrollBar/Utils/ConvenienceFunctions.swift
+++ b/DMScrollBar/Utils/ConvenienceFunctions.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UIKit
 
 func interval<T: Comparable>(_ minimum: T, _ num: T, _ maximum: T) -> T {
     return min(maximum, max(minimum, num))

--- a/DMScrollBar/Utils/Sequence+Utils.swift
+++ b/DMScrollBar/Utils/Sequence+Utils.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension Sequence where Element == DMScrollBar.Configuration.RoundedCorners.Corner {
     var cornerMask: CACornerMask {
         CACornerMask(map(\.cornerMask))

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version:5.7
+import PackageDescription
+
+let package = Package(
+    name: "DMScrollBar",
+    platforms: [.iOS(.v14)],
+    products: [
+        .library(
+            name: "DMScrollBar",
+            targets: ["DMScrollBar"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "DMScrollBar",
+            path: "DMScrollBar"
+        )
+    ]
+)


### PR DESCRIPTION
### Background
You need it, man!
<img src="https://media2.giphy.com/media/d3mlE7uhX8KFgEmY/giphy.gif"/>

### What has been done?
1. I've added `Package.swift`
2. I've added missing imports because CocoaPods is generating the ObjC header file that includes the Foundation and UIKit imports, but SPM does not do it. Have to import manually.

### How to test?
1. Just type in the command line `xed .`
2. The SPM-generated project should be opened.
3. Build should be successful.